### PR TITLE
Include files from extracted protos

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 repositories {
     gradlePluginPortal()
+    mavenCentral()
 }
 
 plugins {
@@ -90,7 +91,7 @@ tasks {
 }
 
 dependencies {
-    testImplementation("org.junit.jupiter:junit-jupiter:5.7.2")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
     testImplementation("com.google.truth:truth:1.1.3")
 }
 

--- a/src/main/kotlin/com/parmet/buf/gradle/BufPlugin.kt
+++ b/src/main/kotlin/com/parmet/buf/gradle/BufPlugin.kt
@@ -20,8 +20,6 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.create
 
-internal const val EXTRACT_INCLUDE_PROTO_TASK_NAME = "extractIncludeProto"
-
 const val BUF_CONFIGURATION_NAME = "buf"
 
 class BufPlugin : Plugin<Project> {

--- a/src/main/kotlin/com/parmet/buf/gradle/Workspace.kt
+++ b/src/main/kotlin/com/parmet/buf/gradle/Workspace.kt
@@ -4,6 +4,7 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.kotlin.dsl.get
@@ -20,13 +21,9 @@ private const val BUILD_EXTRACTED_PROTOS_MAIN = "build/extracted-protos/main"
 
 internal fun Project.configureCreateSymLinksToModules() {
     tasks.register(CREATE_SYM_LINKS_TO_MODULES_TASK_NAME) {
-        dependsOn(EXTRACT_INCLUDE_PROTO_TASK_NAME)
-        dependsOn(EXTRACT_PROTO_TASK_NAME)
-
-        outputs.dir(bufbuildDir)
+        workspaceCommonConfig()
 
         doLast {
-            File(bufbuildDir).mkdirs()
             protoDirs().forEach { createSymLink(it) }
         }
     }
@@ -42,9 +39,9 @@ private fun Project.createSymLink(protoDir: Path) {
 
 internal fun Project.configureWriteWorkspaceYaml() {
     tasks.register(WRITE_WORKSPACE_YAML_TASK_NAME) {
-        outputs.dir(bufbuildDir)
+        workspaceCommonConfig()
+
         doLast {
-            File(bufbuildDir).mkdirs()
             val bufWork =
                 """
                     |version: v1
@@ -56,6 +53,15 @@ internal fun Project.configureWriteWorkspaceYaml() {
 
             File("$bufbuildDir/buf.work.yaml").writeText(bufWork)
         }
+    }
+}
+
+private fun Task.workspaceCommonConfig() {
+    dependsOn(EXTRACT_INCLUDE_PROTO_TASK_NAME)
+    dependsOn(EXTRACT_PROTO_TASK_NAME)
+    outputs.dir(project.bufbuildDir)
+    doLast {
+        File(project.bufbuildDir).mkdirs()
     }
 }
 

--- a/src/main/kotlin/com/parmet/buf/gradle/Workspace.kt
+++ b/src/main/kotlin/com/parmet/buf/gradle/Workspace.kt
@@ -2,58 +2,84 @@ package com.parmet.buf.gradle
 
 import java.io.File
 import java.nio.file.Files
-import java.nio.file.Paths
+import java.nio.file.Path
 import org.gradle.api.Project
+import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.the
 
 const val CREATE_SYM_LINKS_TO_MODULES_TASK_NAME = "createSymLinksToModules"
 const val WRITE_WORKSPACE_YAML_TASK_NAME = "writeWorkspaceYaml"
 
-private const val SRC_MAIN_PROTO = "src/main/proto"
+private const val EXTRACT_INCLUDE_PROTO_TASK_NAME = "extractIncludeProto"
 private const val BUILD_EXTRACTED_INCLUDE_PROTOS_MAIN = "build/extracted-include-protos/main"
+
+private const val EXTRACT_PROTO_TASK_NAME = "extractProto"
+private const val BUILD_EXTRACTED_PROTOS_MAIN = "build/extracted-protos/main"
 
 internal fun Project.configureCreateSymLinksToModules() {
     tasks.register(CREATE_SYM_LINKS_TO_MODULES_TASK_NAME) {
         dependsOn(EXTRACT_INCLUDE_PROTO_TASK_NAME)
+        dependsOn(EXTRACT_PROTO_TASK_NAME)
+
         outputs.dir(bufbuildDir)
 
         doLast {
             File(bufbuildDir).mkdirs()
-            createSymLink(SRC_MAIN_PROTO)
-            createSymLink(BUILD_EXTRACTED_INCLUDE_PROTOS_MAIN)
+            protoDirs().forEach { createSymLink(it) }
         }
     }
 }
 
-private fun Project.createSymLink(protoDir: String) {
+private fun Project.createSymLink(protoDir: Path) {
     val symLinkFile = File(bufbuildDir, mangle(protoDir))
-    if (anyProtos(protoDir) && !symLinkFile.exists()) {
+    if (!symLinkFile.exists()) {
         logger.info("Creating symlink for $protoDir at $symLinkFile")
-        Files.createSymbolicLink(symLinkFile.toPath(), Paths.get(bufbuildDir).relativize(file(protoDir).toPath()))
+        Files.createSymbolicLink(symLinkFile.toPath(), Path.of(bufbuildDir).relativize(file(protoDir).toPath()))
     }
 }
-
-private fun mangle(name: String) =
-    name.replace("-", "--").replace(File.separator, "-")
-
-private fun Project.anyProtos(path: String) =
-    file(path).walkTopDown().any { it.extension == "proto" }
 
 internal fun Project.configureWriteWorkspaceYaml() {
     tasks.register(WRITE_WORKSPACE_YAML_TASK_NAME) {
         outputs.dir(bufbuildDir)
         doLast {
             File(bufbuildDir).mkdirs()
-            File("$bufbuildDir/buf.work.yaml").writeText(
+            val bufWork =
                 """
-                    version: v1
-                    directories:
-                      ${entry(SRC_MAIN_PROTO)}
-                      ${entry(BUILD_EXTRACTED_INCLUDE_PROTOS_MAIN)}
-                """.trimIndent()
-            )
+                    |version: v1
+                    |directories:
+                    ${workspaceSymLinkEntries()}
+                """.trimMargin()
+
+            logger.info("Writing generated buf.work.yaml: \n$bufWork")
+
+            File("$bufbuildDir/buf.work.yaml").writeText(bufWork)
         }
     }
 }
 
-private fun Project.entry(path: String) =
-    if (anyProtos(path)) "- ${mangle(path)}" else ""
+private fun Project.workspaceSymLinkEntries() =
+    protoDirs().joinToString("\n") { "|  - ${mangle(it)}" }
+
+private fun Project.protoDirs(): List<Path> =
+    potentialProtoDirs().filter { anyProtos(it) }
+
+private fun Project.potentialProtoDirs() =
+    the<SourceSetContainer>()["main"]
+        .extensions
+        .getByName("proto")
+        .let { it as SourceDirectorySet }
+        .let { sourceDirSet ->
+            sourceDirSet.srcDirs.map { projectDir.toPath().relativize(it.toPath()) }
+        } +
+            listOf(
+                BUILD_EXTRACTED_INCLUDE_PROTOS_MAIN,
+                BUILD_EXTRACTED_PROTOS_MAIN
+            ).map(Path::of)
+
+private fun Project.anyProtos(path: Path) =
+    file(path).walkTopDown().any { it.extension == "proto" }
+
+private fun mangle(name: Path) =
+    name.toString().replace("-", "--").replace(File.separator, "-")

--- a/src/main/kotlin/com/parmet/buf/gradle/Workspace.kt
+++ b/src/main/kotlin/com/parmet/buf/gradle/Workspace.kt
@@ -63,20 +63,21 @@ private fun Project.workspaceSymLinkEntries() =
     protoDirs().joinToString("\n") { "|  - ${mangle(it)}" }
 
 private fun Project.protoDirs(): List<Path> =
-    potentialProtoDirs().filter { anyProtos(it) }
+    (srcDirs() + extractDirs()).filter { anyProtos(it) }
 
-private fun Project.potentialProtoDirs() =
+private fun Project.srcDirs() =
     the<SourceSetContainer>()["main"]
         .extensions
         .getByName("proto")
         .let { it as SourceDirectorySet }
-        .let { sourceDirSet ->
-            sourceDirSet.srcDirs.map { projectDir.toPath().relativize(it.toPath()) }
-        } +
-            listOf(
-                BUILD_EXTRACTED_INCLUDE_PROTOS_MAIN,
-                BUILD_EXTRACTED_PROTOS_MAIN
-            ).map(Path::of)
+        .srcDirs
+        .map { projectDir.toPath().relativize(it.toPath()) }
+
+private fun extractDirs() =
+    listOf(
+        BUILD_EXTRACTED_INCLUDE_PROTOS_MAIN,
+        BUILD_EXTRACTED_PROTOS_MAIN
+    ).map(Path::of)
 
 private fun Project.anyProtos(path: Path) =
     file(path).walkTopDown().any { it.extension == "proto" }

--- a/src/test/kotlin/com/parmet/buf/gradle/LintTest.kt
+++ b/src/test/kotlin/com/parmet/buf/gradle/LintTest.kt
@@ -67,6 +67,26 @@ class LintTest : AbstractBufIntegrationTest() {
         assertThat(result.output).contains("config file location and a dependency; pick one")
     }
 
+    @Test
+    fun `linting a separate protobuf source directory through the protobuf-gradle-plugin`() {
+        assertSuccess()
+    }
+
+    @Test
+    fun `linting a file with a google dependency with the protobuf-gradle-plugin`() {
+        assertSuccess()
+    }
+
+    @Test
+    fun `linting a file with a protobuf dependency with the protobuf-gradle-plugin`() {
+        assertSuccess()
+    }
+
+    @Test
+    fun `linting a file with a protobuf dependency and a google dependency with the protobuf-gradle-plugin`() {
+        assertSuccess()
+    }
+
     private fun assertLocationFailure() {
         val result = checkRunner().buildAndFail()
         assertThat(result.task(":bufLint")?.outcome).isEqualTo(FAILED)

--- a/src/test/resources/LintTest/linting a file with a google dependency with the protobuf-gradle-plugin/buf.yaml
+++ b/src/test/resources/LintTest/linting a file with a google dependency with the protobuf-gradle-plugin/buf.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 Andrew Parmet
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: v1
+lint:
+  ignore:
+    - google

--- a/src/test/resources/LintTest/linting a file with a google dependency with the protobuf-gradle-plugin/build.gradle
+++ b/src/test/resources/LintTest/linting a file with a google dependency with the protobuf-gradle-plugin/build.gradle
@@ -30,5 +30,5 @@ protobuf {
 compileJava.enabled = false
 
 dependencies {
-  buf fileTree('subdir') { include '*.yaml' }
+  implementation "com.google.protobuf:protobuf-java:3.18.0"
 }

--- a/src/test/resources/LintTest/linting a file with a google dependency with the protobuf-gradle-plugin/src/main/proto/parmet/buf/test/v1/test.proto
+++ b/src/test/resources/LintTest/linting a file with a google dependency with the protobuf-gradle-plugin/src/main/proto/parmet/buf/test/v1/test.proto
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 Andrew Parmet
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package parmet.buf.test.v1;
+
+import "google/protobuf/any.proto";
+
+message BasicMessage {
+  google.protobuf.Any any = 1;
+}

--- a/src/test/resources/LintTest/linting a file with a protobuf dependency and a google dependency with the protobuf-gradle-plugin/buf.yaml
+++ b/src/test/resources/LintTest/linting a file with a protobuf dependency and a google dependency with the protobuf-gradle-plugin/buf.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2021 Andrew Parmet
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: v1
+lint:
+  ignore:
+    - google
+    - protokt

--- a/src/test/resources/LintTest/linting a file with a protobuf dependency and a google dependency with the protobuf-gradle-plugin/build.gradle
+++ b/src/test/resources/LintTest/linting a file with a protobuf dependency and a google dependency with the protobuf-gradle-plugin/build.gradle
@@ -30,5 +30,6 @@ protobuf {
 compileJava.enabled = false
 
 dependencies {
-  buf fileTree('subdir') { include '*.yaml' }
+  implementation "com.google.protobuf:protobuf-java:3.18.0"
+  protobuf "com.toasttab.protokt:protokt-runtime:0.6.5"
 }

--- a/src/test/resources/LintTest/linting a file with a protobuf dependency and a google dependency with the protobuf-gradle-plugin/src/main/proto/parmet/buf/test/v1/test.proto
+++ b/src/test/resources/LintTest/linting a file with a protobuf dependency and a google dependency with the protobuf-gradle-plugin/src/main/proto/parmet/buf/test/v1/test.proto
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 Andrew Parmet
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package parmet.buf.test.v1;
+
+import "google/protobuf/any.proto";
+import "protokt/protokt.proto";
+
+message BasicMessage {
+  google.protobuf.Any any = 1;
+  protokt.ProtoktFileOptions protokt_file_options = 2;
+}

--- a/src/test/resources/LintTest/linting a file with a protobuf dependency with the protobuf-gradle-plugin/build.gradle
+++ b/src/test/resources/LintTest/linting a file with a protobuf dependency with the protobuf-gradle-plugin/build.gradle
@@ -30,5 +30,5 @@ protobuf {
 compileJava.enabled = false
 
 dependencies {
-  buf fileTree('subdir') { include '*.yaml' }
+  protobuf files('subdir')
 }

--- a/src/test/resources/LintTest/linting a file with a protobuf dependency with the protobuf-gradle-plugin/src/main/proto/parmet/buf/test/v1/test.proto
+++ b/src/test/resources/LintTest/linting a file with a protobuf dependency with the protobuf-gradle-plugin/src/main/proto/parmet/buf/test/v1/test.proto
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 Andrew Parmet
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package parmet.buf.test.v1;
+
+import "foo/v1/test.proto";
+
+message BasicMessage2 {
+  foo.v1.BasicMessage1 basic_message_1 = 1;
+}

--- a/src/test/resources/LintTest/linting a file with a protobuf dependency with the protobuf-gradle-plugin/subdir/foo/v1/test.proto
+++ b/src/test/resources/LintTest/linting a file with a protobuf dependency with the protobuf-gradle-plugin/subdir/foo/v1/test.proto
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 Andrew Parmet
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package foo.v1;
+
+message BasicMessage1 {}

--- a/src/test/resources/LintTest/linting a separate protobuf source directory through the protobuf-gradle-plugin/build.gradle
+++ b/src/test/resources/LintTest/linting a separate protobuf source directory through the protobuf-gradle-plugin/build.gradle
@@ -29,6 +29,10 @@ protobuf {
 
 compileJava.enabled = false
 
-dependencies {
-  buf fileTree('subdir') { include '*.yaml' }
+sourceSets {
+  main {
+    proto {
+      srcDir 'subdir'
+    }
+  }
 }

--- a/src/test/resources/LintTest/linting a separate protobuf source directory through the protobuf-gradle-plugin/subdir/parmet/buf/test/v1/test.proto
+++ b/src/test/resources/LintTest/linting a separate protobuf source directory through the protobuf-gradle-plugin/subdir/parmet/buf/test/v1/test.proto
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 Andrew Parmet
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package parmet.buf.test.v1;
+
+message BasicMessage {}


### PR DESCRIPTION
to do:

- [x] rework tests to act against concrete code, not ephemeral test-generated code
- [x] add test that uses the `protobuf` configuration to test `extracted-protos` resolution
- [ ] add test that has two copies of the same file from two different modules