### PR TITLE
added '--rm' to docker command to clean up container after use

### DIFF
--- a/src/main/kotlin/com/parmet/buf/gradle/DockerSupport.kt
+++ b/src/main/kotlin/com/parmet/buf/gradle/DockerSupport.kt
@@ -46,6 +46,7 @@ private fun Project.resolveConfig(ext: BufExtension): File? =
 private fun Project.baseDockerArgs(ext: BufExtension) =
     listOf(
         "run",
+        "--rm",
         "--volume", "$projectDir:/workspace:Z",
         "--workdir", "/workspace/build/bufbuild",
         "bufbuild/buf:${ext.toolVersion}"


### PR DESCRIPTION
I didn't see anything that indicated I needed to manually up the version, but if there is, I'll do that before merging.

This patch adds `--rm` to the arguments passed to Docker when `buf` is invoked. This cleans up the list of stopped containers on a system.

For testing, I ran the tests included in `./gradle test` and watched as containers were created to run buf and were immediately deleted after they terminated. All tests still passed.