### PR TITLE
update GitHub workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,27 +12,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
+          check-latest: true
 
       - name: Build
-        run: ./gradlew build --info
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build --info
 
       - name: Publish unit test results
         uses: EnricoMi/publish-unit-test-result-action@v1
@@ -40,4 +38,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           files: "**/test-results/**/*.xml"
-          comment_on_pr: false
+          comment_mode: off

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,26 +13,31 @@ jobs:
     environment: publication
 
     steps:
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
 
-      - name: Publish
-        run: ./gradlew publishToRemote closeAndReleaseRepository publishPlugins -Dorg.gradle.internal.http.socketTimeout=120000 -Dorg.gradle.internal.network.retry.max.attempts=1 -Dorg.gradle.internal.publish.checksums.insecure=true
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+          check-latest: true
+
+      - name: Build
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: |
+            publishToRemote
+            closeAndReleaseRepository
+            publishPlugins
+            -Dorg.gradle.internal.http.socketTimeout=120000
+            -Dorg.gradle.internal.network.retry.max.attempts=1
+            -Dorg.gradle.internal.publish.checksums.insecure=true
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}


### PR DESCRIPTION
I've updated workflows to use the latest actions versions.
I've also used:
* https://github.com/gradle/wrapper-validation-action to validate the wrapper which is committed to the repository
* https://github.com/gradle/gradle-build-action to set up and run Gradle with included caching